### PR TITLE
update camera info continuously

### DIFF
--- a/ar_track_alvar/src/Camera.cpp
+++ b/ar_track_alvar/src/Camera.cpp
@@ -259,11 +259,11 @@ void Camera::SetCameraInfo(const sensor_msgs::CameraInfo &camInfo)
 
 void Camera::camInfoCallback (const sensor_msgs::CameraInfoConstPtr & cam_info)
   {
-    if (!getCamInfo_)
+//    if (!getCamInfo_)
     {
         SetCameraInfo(*cam_info);
         getCamInfo_ = true;
-        sub_.shutdown();
+//        sub_.shutdown();
     }
   }
 


### PR DESCRIPTION
- this is needed for zoom cameras, because the focal length changes depending on the zoom level